### PR TITLE
refactor(db): store webhookUrl instead

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,17 +67,17 @@ model blacklistedUsers {
 }
 
 model connectedList {
-  id         String          @id @default(auto()) @map("_id") @db.ObjectId
-  channelId  String          @unique
+  id         String   @id @default(auto()) @map("_id") @db.ObjectId
+  channelId  String   @unique
   serverId   String
   connected  Boolean
   compact    Boolean
   invite     String?
   profFilter Boolean
-  webhook    NetworkWebhook
-  date       DateTime        @default(now())
-  hub        hubs?           @relation(fields: [hubId], references: [id])
-  hubId      String?         @db.ObjectId
+  webhookURL String
+  date       DateTime @default(now())
+  hub        hubs?    @relation(fields: [hubId], references: [id])
+  hubId      String   @db.ObjectId
 }
 
 model hubs {

--- a/src/Commands/Network/editMsg.ts
+++ b/src/Commands/Network/editMsg.ts
@@ -85,7 +85,7 @@ export default {
           const channelSettings = channelSettingsArr.find(c => c.channelId === obj.channelId);
 
           if (channelSettings) {
-            const webhook = new WebhookClient({ id: channelSettings.webhook.id, token: channelSettings.webhook.token });
+            const webhook = new WebhookClient({ url: channelSettings.webhookURL });
             const compact = channelSettings?.profFilter ? newMessage : censoredNewMessage;
             const webhookEmbed = channelSettings?.profFilter ? censoredEmbed : newEmbed;
 

--- a/src/Events/messageCreate.ts
+++ b/src/Events/messageCreate.ts
@@ -12,7 +12,7 @@ export interface NetworkMessage extends Message {
 
 export interface NetworkWebhookSendResult {
   message: APIMessage | null
-  webhookId: string;
+  webhookURL: string;
 }
 
 export default {
@@ -120,13 +120,13 @@ export default {
           };
         }
 
-        const webhook = new WebhookClient({ id: `${connection?.webhook.id}`, token: `${connection?.webhook.token}` });
+        const webhook = new WebhookClient({ url: connection.webhookURL });
         const webhookSendRes = await webhook.send(webhookMessage).catch(() => null);
-        return { webhookId: webhook.id, message: webhookSendRes } as NetworkWebhookSendResult;
+        return { webhookURL: webhook.url, message: webhookSendRes } as NetworkWebhookSendResult;
       });
 
       message.delete().catch(() => null);
-      cleanup.execute(message, await Promise.all(messageResults), channelInDb.hubId);
+      cleanup(message, await Promise.all(messageResults), channelInDb.hubId);
     }
   },
 };

--- a/src/Scripts/message/cleanup.ts
+++ b/src/Scripts/message/cleanup.ts
@@ -2,49 +2,46 @@ import { Message } from 'discord.js';
 import { NetworkWebhookSendResult } from '../../Events/messageCreate';
 import { getDb } from '../../Utils/functions/utils';
 
-export default {
-  /**
-   * Disconnects connections if an errored occured while sending the message to it.
-   * Otherwise, inserts messages into `messageData` collection for future use.
-   */
-  async execute(message: Message, channelAndMessageIds: NetworkWebhookSendResult[], hubId: string | null) {
-    // All message data is stored in the database, so we can delete the message from the network later
-    const messageDataObj: { channelId: string, messageId: string }[] = [];
-    const invalidWebhookIds: string[] = [];
+/**
+  * Disconnects connections if an errored occured while sending the message to it.
+  * Otherwise, inserts messages into `messageData` collection for future use.
+  */
+export default async function execute(message: Message, channelAndMessageIds: NetworkWebhookSendResult[], hubId: string | null) {
+  const messageDataObj: { channelId: string, messageId: string }[] = [];
+  const invalidWebhookURLs: string[] = [];
 
-    channelAndMessageIds.forEach((result) => {
-      if (!result.message) {
-        invalidWebhookIds.push(result.webhookId);
-      }
-      else {
-        messageDataObj.push({
-          channelId: result.message.channel_id,
-          messageId: result.message.id,
-        });
-      }
+  channelAndMessageIds.forEach((result) => {
+    if (!result.message) {
+      invalidWebhookURLs.push(result.webhookURL);
+    }
+    else {
+      messageDataObj.push({
+        channelId: result.message.channel_id,
+        messageId: result.message.id,
+      });
+    }
+  });
+
+  const db = getDb();
+  if (message.guild && hubId) {
+    // store message data in db
+    await db.messageData.create({
+      data: {
+        hub: { connect: { id: hubId } },
+        channelAndMessageIds: messageDataObj,
+        timestamp: message.createdAt,
+        authorId: message.author.id,
+        serverId: message.guild.id,
+        reference: message.reference,
+      },
     });
+  }
 
-    const db = getDb();
-    if (message.guild && hubId) {
-      // store message data in db
-      await db.messageData.create({
-        data: {
-          hub: { connect: { id: hubId } },
-          channelAndMessageIds: messageDataObj,
-          timestamp: message.createdAt,
-          authorId: message.author.id,
-          serverId: message.guild.id,
-          reference: message.reference,
-        },
-      });
-    }
-
-    // disconnect network if, webhook does not exist/bot cannot access webhook
-    if (invalidWebhookIds.length > 0) {
-      await db.connectedList.updateMany({
-        where: { webhook: { is: { id: { in: invalidWebhookIds } } } },
-        data: { connected: false },
-      });
-    }
-  },
-};
+  // disconnect network if, webhook does not exist/bot cannot access webhook
+  if (invalidWebhookURLs.length > 0) {
+    await db.connectedList.updateMany({
+      where: { webhookURL: { in: invalidWebhookURLs } },
+      data: { connected: false },
+    });
+  }
+}

--- a/src/Scripts/network/displaySettings.ts
+++ b/src/Scripts/network/displaySettings.ts
@@ -248,7 +248,7 @@ export = {
             where: { channelId: updConnection.channelId },
             data: {
               channelId: channel?.id,
-              webhook: { id: webhook.id, token: `${webhook.token}`, url: webhook.url },
+              webhookURL: webhook.url,
             },
           });
 

--- a/src/Scripts/network/initialize.ts
+++ b/src/Scripts/network/initialize.ts
@@ -49,7 +49,7 @@ export = {
           connected: true,
           profFilter: true,
           compact: false,
-          webhook: { id: webhook.id, token: `${webhook.token}`, url: webhook.url },
+          webhookURL: webhook.url,
           hub: { connect: { id: hub.id } },
         },
       });


### PR DESCRIPTION
Storing objects with URL, id, and token takes significantly more space in the database. So only storing the URL as a string will reduce the size, without losing any of the data. Parse the id, and token from the string itself.

Resolves IC-71 